### PR TITLE
Add color-coded environment badge and dynamic tooltip

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,31 +1,52 @@
-chrome.runtime.onInstalled.addListener(() => {
-    chrome.action.setBadgeText({
-        text: "OFF",
-    });
-});
-
 const ksc = /https:\/\/.*\.kelsey-seybold\.com/;
 const sitecore = /https:\/\/.*\.ksnet\.com/;
+const uatPattern = /uatnew-www\./;
 
-chrome.action.onClicked.addListener(async(tab) => {
-    if (tab.url.match(sitecore) || tab.url.match(ksc)) {
-        // Retrieve the action badge to check if the extension is on or off
-        const prevState = await chrome.action.getBadgeText({ tabId: tab.id });
-        // Next state will always be the opposite
-        const nextState = prevState === 'ON' ? 'OFF' : 'ON'
+function isKscSite(url) {
+    return url && (url.match(ksc) || url.match(sitecore));
+}
 
-        // Set the action badge to the next state
-        await chrome.action.setBadgeText({
-            tabId: tab.id,
-            text: nextState,
-        });
+function isUat(url) {
+    return uatPattern.test(url);
+}
 
-        if (nextState === "ON") {
-            await chrome.scripting.executeScript({
-                files: ["switch.js"],
-                target: { tabId: tab.id },
-            })
-        }
+async function updateBadge(tabId, url) {
+    if (!isKscSite(url)) {
+        await chrome.action.setBadgeText({ tabId, text: "" });
+        await chrome.action.setTitle({ tabId, title: "Not on a KSC site" });
+        return;
     }
 
-})
+    if (isUat(url)) {
+        await chrome.action.setBadgeText({ tabId, text: "UAT" });
+        await chrome.action.setBadgeBackgroundColor({ tabId, color: "#F59E0B" });
+        await chrome.action.setTitle({ tabId, title: "Switch to PROD" });
+    } else {
+        await chrome.action.setBadgeText({ tabId, text: "PRD" });
+        await chrome.action.setBadgeBackgroundColor({ tabId, color: "#10B981" });
+        await chrome.action.setTitle({ tabId, title: "Switch to UAT" });
+    }
+}
+
+// Update badge when a tab's URL changes
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.url || changeInfo.status === "complete") {
+        updateBadge(tabId, tab.url);
+    }
+});
+
+// Update badge when switching tabs
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+    const tab = await chrome.tabs.get(tabId);
+    updateBadge(tabId, tab.url);
+});
+
+// Single click to switch environments
+chrome.action.onClicked.addListener(async (tab) => {
+    if (isKscSite(tab.url)) {
+        await chrome.scripting.executeScript({
+            files: ["switch.js"],
+            target: { tabId: tab.id },
+        });
+    }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -13,9 +13,9 @@
         "128": "images/icon128.png"
     },
     "action": {
-
+        "default_title": "UAT-PROD Switcher"
     },
-    "permissions": ["activeTab", "scripting"],
+    "permissions": ["activeTab", "scripting", "tabs"],
     "commands": {
         "_execute_action": {
             "suggested_key": {


### PR DESCRIPTION
- Orange "UAT" badge / green "PRD" badge based on current URL
- Tooltip shows "Switch to PROD" or "Switch to UAT" on hover
- Badge updates automatically on page load and tab switch
- No badge shown when not on a KSC site
- Removes the misleading ON/OFF toggle in favor of environment awareness